### PR TITLE
feat:添加gitignore从而避免上传mac拉出来的.DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# dependencies
+node_modules
+.pnp
+.pnp.js
+
+# testing
+coverage
+
+# next.js
+.next/
+out/
+.swc
+build
+
+# misc
+.DS_Store
+*.pem
+.eslintcache
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Node build artifacts
+dist


### PR DESCRIPTION
发现一些mac拉出来的DS_Store捏，通过添加gitignore来避免该问题重复出现；
<img width="482" alt="image" src="https://github.com/user-attachments/assets/4fc8135b-2316-4a98-8a47-36ca733f7f9f">
